### PR TITLE
RoseTTAFold2NA support multi-chain PDB output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ wget ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/rfam/rfam_anno
 wget ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/id_mapping/id_mapping.tsv.gz
 wget ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/sequences/rnacentral_species_specific_ids.fasta.gz
 ../input_prep/reprocess_rnac.pl id_mapping.tsv.gz rfam_annotations.tsv.gz   # ~8 minutes
-gunzip -c rnacentral_species_specific_ids.fasta.gz | makeblastdb -in - -dbtype nucl  -out rnacentral.fasta -title "RNACentral"
+gunzip -c rnacentral_species_specific_ids.fasta.gz | makeblastdb -in - -dbtype nucl -parse_seqids -out rnacentral.fasta -title "RNACentral"
 
 # nt [151G]
 update_blastdb.pl --decompress nt

--- a/input_prep/make_rna_msa.sh
+++ b/input_prep/make_rna_msa.sh
@@ -13,7 +13,7 @@ MEM="$5"
 
 # databases
 db0="$PIPEDIR/RNA/Rfam.cm";
-db1="$PIPEDIR/RNA/rnacentral2.fasta";
+db1="$PIPEDIR/RNA/rnacentral.fasta";
 db2="$PIPEDIR/RNA/nt";
 db0to1="$PIPEDIR/RNA/rfam_annotations.tsv.gz";
 db0to2="$PIPEDIR/RNA/Rfam.full_region.gz";

--- a/network/chemical.py
+++ b/network/chemical.py
@@ -1,6 +1,8 @@
 import torch
 import numpy as np
 
+PDB_CHAIN_IDS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
 num2aa=[
     'ALA','ARG','ASN','ASP','CYS',
     'GLN','GLU','GLY','HIS','ILE',

--- a/network/data_loader.py
+++ b/network/data_loader.py
@@ -803,6 +803,8 @@ def merge_a3m_homo(msa_orig, ins_orig, nmer):
 
 # Generate input features for single-chain
 def featurize_single_chain(msa, ins, tplt, pdb, params, unclamp=False, pick_top=True):
+
+    #print("msa: ", msa.min(), msa.max(), msa.shape)
     seq, msa_seed_orig, msa_seed, msa_extra, mask_msa = MSAFeaturize(msa, ins, params)
     
     # get template features

--- a/network/parsers.py
+++ b/network/parsers.py
@@ -74,6 +74,21 @@ def parse_fasta(filename,  maxseq=10000, rna_alphabet=False, dna_alphabet=False)
 
     fstream = open(filename,"r")
     table = str.maketrans(dict.fromkeys(string.ascii_lowercase))
+    table_na = {}
+    if rna_alphabet or dna_alphabet:
+        table_na.update(str.maketrans(dict.fromkeys(string.ascii_uppercase)))
+        del table_na[ord('A')]
+        del table_na[ord('C')]
+        del table_na[ord('G')]
+        del table_na[ord('T')]
+        if rna_alphabet:
+            del table_na[ord('N')]
+            del table_na[ord('U')]
+        if dna_alphabet:
+            del table_na[ord('D')]
+        for k,v in table_na.items():
+            table_na[k] = '-'
+
 
     for line in fstream:
         # skip labels
@@ -88,9 +103,9 @@ def parse_fasta(filename,  maxseq=10000, rna_alphabet=False, dna_alphabet=False)
 
         # remove lowercase letters and append to MSA
         msa_i = line.translate(table)
+        msa_i = line.translate(table_na)
         msa_i = msa_i.replace('B','D') # hacky...
         msa.append(msa_i)
-
         # sequence length
         L = len(msa[-1])
 

--- a/network/util.py
+++ b/network/util.py
@@ -237,7 +237,15 @@ def get_tips(xyz, seq):
 
 
 # writepdb
-def writepdb(filename, atoms, seq, idx_pdb=None, bfacts=None):
+def writepdb(filename, atoms, seq, chain_index, residue_index, bfacts=None):
+
+    print("atoms:", atoms.shape)
+    print("seq:", seq.shape)
+    print("chain_index:", chain_index.shape)
+    print("residue_index:", residue_index.shape)
+    if bfacts is not None:
+        print("bfacts:", bfacts.shape)
+
     f = open(filename,"w")
     ctr = 1
     scpu = seq.cpu().squeeze(0)
@@ -245,8 +253,8 @@ def writepdb(filename, atoms, seq, idx_pdb=None, bfacts=None):
 
     if bfacts is None:
         bfacts = torch.zeros(atomscpu.shape[0])
-    if idx_pdb is None:
-        idx_pdb = 1 + torch.arange(atomscpu.shape[0])
+    #if idx_pdb is None:
+    #    idx_pdb = 1 + torch.arange(atomscpu.shape[0])
 
     Bfacts = torch.clamp( bfacts.cpu(), 0, 1)
     for i,s in enumerate(scpu):
@@ -254,6 +262,10 @@ def writepdb(filename, atoms, seq, idx_pdb=None, bfacts=None):
         if (natoms!=NHEAVY and natoms!=NTOTAL):
             print ('bad size!', natoms, NHEAVY, NTOTAL, atoms.shape)
             assert(False)
+
+        res_idx = residue_index[i] # Residue index (1-N)
+        ch_idx  = chain_index[i]   # Chain index (0-N)
+        ch_name = PDB_CHAIN_IDS[ch_idx] # Chain symbol (ABCDE...)
 
         atms = aa2long[s]
 
@@ -268,7 +280,7 @@ def writepdb(filename, atoms, seq, idx_pdb=None, bfacts=None):
             if (j<natoms and atm_j is not None and not torch.isnan(atomscpu[i,j,:]).any()):
                 f.write ("%-6s%5s %4s %3s %s%4d    %8.3f%8.3f%8.3f%6.2f%6.2f\n"%(
                     "ATOM", ctr, atm_j, num2aa[s], 
-                    "A", idx_pdb[i], atomscpu[i,j,0], atomscpu[i,j,1], atomscpu[i,j,2],
+                    ch_name, res_idx, atomscpu[i,j,0], atomscpu[i,j,1], atomscpu[i,j,2],
                     1.0, Bfacts[i] ) )
                 ctr += 1
 


### PR DESCRIPTION
I have some modifications on RoseTTAFold2NA (main brach):
1. Add "-parse_seqids" to makeblastdb;
2. Change "-M 5000" to "-M 0" (cd-hit-est) and add "-M first" (hhfilter) to disable error during generating RNA MSA;
3. network/parsers.py: Use table_na to filter nucleotide not in ('A', 'T', 'C', 'G', 'U', 'D', 'N'), otherwise the program will crash;
4. network/predict.py: Add `chain_index` and `residue_index` to support multi-chain PDB output.