### PR TITLE
Make FASTA filepath/type parser work with absolute FASTA filepaths

### DIFF
--- a/run_RF2NA.sh
+++ b/run_RF2NA.sh
@@ -79,7 +79,7 @@ do
     type=`echo $i | awk -F: '{if (NF==1) {print "P"} else {print $1}}'`
     type=${type^^}
     fasta=`echo $i`
-    fasta_name=`echo $i | awk -F: '{if (NF==1) {print $1} else {print $2}}'`
+    fasta_name=`echo $fasta | awk -F: '{if (NF==1) {print $1} else {print $2}}'`
     tag=`basename $fasta_name | sed -E 's/\.fasta$|\.fas$|\.fa$//'`
     type=`basename $type`  # extract only the last component after the last '/', so users can pass in an absolute path for each FASTA
 

--- a/run_RF2NA.sh
+++ b/run_RF2NA.sh
@@ -80,6 +80,7 @@ do
     type=${type^^}
     fasta=`echo $i | awk -F: '{if (NF==1) {print $1} else {print $2}}'`
     tag=`basename $fasta | sed -E 's/\.fasta$|\.fas$|\.fa$//'`
+    type=`basename $type`  # extract only the last component after the last '/', so users can pass in an absolute path for each FASTA
 
     if [ $type = 'P' ]
     then

--- a/run_RF2NA.sh
+++ b/run_RF2NA.sh
@@ -78,8 +78,9 @@ for i in "$@"
 do
     type=`echo $i | awk -F: '{if (NF==1) {print "P"} else {print $1}}'`
     type=${type^^}
-    fasta=`echo $i | awk -F: '{if (NF==1) {print $1} else {print $2}}'`
-    tag=`basename $fasta | sed -E 's/\.fasta$|\.fas$|\.fa$//'`
+    fasta=`echo $i`
+    fasta_name=`echo $i | awk -F: '{if (NF==1) {print $1} else {print $2}}'`
+    tag=`basename $fasta_name | sed -E 's/\.fasta$|\.fas$|\.fa$//'`
     type=`basename $type`  # extract only the last component after the last '/', so users can pass in an absolute path for each FASTA
 
     if [ $type = 'P' ]


### PR DESCRIPTION
* Makes the existing FASTA filepath/type parser (in Bash) work with absolute FASTA filepath inputs (rather than only relative filepaths).