### PR TITLE
Apptainer Def File

### DIFF
--- a/Apptainer/RF2NA.def
+++ b/Apptainer/RF2NA.def
@@ -1,0 +1,66 @@
+Bootstrap: docker
+From: nvidia/cuda:12.3.1-runtime-ubuntu22.04
+
+%labels
+    Author Hong Tao 
+    Maintainer  hong.tao@imba.oew.ac.at
+    URL https://clip.science
+
+%files
+
+%environment
+    export BASH_ENV=/opt/etc/bashrc
+    export PATH="/opt/miniconda3/bin/:$PATH"
+    
+%post
+    export PATH="/opt/miniconda3/bin/:$PATH"
+    cd /opt
+    mkdir -p miniconda3
+    apt update && apt install -y wget git
+    rm -rf /var/lib/apt/lists/*
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /opt/miniconda3/miniconda.sh
+    bash /opt/miniconda3/miniconda.sh -b -u -p /opt/miniconda3
+    rm -rf /opt/miniconda3/miniconda.sh   
+    conda init bash
+    conda install conda-forge::conda-ecosystem-user-package-isolation
+   
+    git clone https://github.com/w34sel/RoseTTAFold2NA.git 
+    cd RoseTTAFold2NA
+    git checkout 43b6d52
+    conda config --set channel_priority flexible
+    conda env create -f RF2na-linux.yml 
+    echo "#! /bin/bash" >> ~/.bashrc  
+    echo "\n\n" >> ~/.bashrc 
+    echo "# script to activate the conda environment" > ~/.bashrc 
+    conda init bash 
+    echo "\n" >> ~/.bashrc 
+    echo "conda activate RF2NA" >> ~/.bashrc 
+    echo "echo \"RF2NA running ...\"" >>  ~/.bashrc 
+    conda clean -a 
+    mkdir /opt/etc/ 
+    cp ~/.bashrc /opt/etc/bashrc
+
+    .  /opt/etc/bashrc
+    cd SE3Transformer
+    pip install --no-cache-dir -r requirements.txt
+    python setup.py install
+    cd ..
+    cd network
+    wget https://files.ipd.uw.edu/dimaio/RF2NA_apr23.tgz
+    tar xvfz RF2NA_apr23.tgz
+    ls weights/ # it should contain a 1.1GB weights file
+    rm RF2NA_apr23.tgz
+    cd ..
+
+%runscript
+    exec /opt/RoseTTAFold2NA/run_RF2NA.sh "$@"
+
+%test
+
+%help
+
+    # Mount the DB's into the container
+    export APPTAINER_BIND="<local_path>:/opt/RoseTTAFold2NA/bfd,<local_path>:/opt/RoseTTAFold2NA/RNA,<local_path>:/opt/RoseTTAFold2NA/UniR>
+
+    # run rosetta2nafold
+    apptainer run --nv <container_name> <output_dir> <fa_filename> <type_RNA_DNA>

--- a/RF2na-linux.yml
+++ b/RF2na-linux.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python=3.10
   - pip
-  - pytorch
+  - pytorch::pytorch=2.0
   - requests
   - pytorch-cuda=11.7
   - dglteam/label/cu117::dgl

--- a/input_prep/make_rna_msa.sh
+++ b/input_prep/make_rna_msa.sh
@@ -6,7 +6,7 @@ out_dir="$2"
 out_tag="$3"
 
 overwrite=true
-if [ -f $out_dir/$out_tag.afa -a $overwrite = false]
+if [ -f $out_dir/$out_tag.afa -a $overwrite = false ]
 then
     exit 0
 fi

--- a/run_RF2NA.sh
+++ b/run_RF2NA.sh
@@ -12,14 +12,14 @@ unset __conda_setup
 # <<< conda initialize <<<
 ############################################################
 
-SCRIPT=`realpath -s $0`
+SCRIPT=`realpath $0`
 export PIPEDIR=`dirname $SCRIPT`
 HHDB="$PIPEDIR/pdb100_2021Mar03/pdb100_2021Mar03"
 
 CPU="8"  # number of CPUs to use
 MEM="64" # max memory (in GB)
 
-WDIR=`realpath -s $1`  # working folder
+WDIR=`realpath $1`  # working folder
 mkdir -p $WDIR/log
 
 conda activate RF2NA


### PR DESCRIPTION
Create a Apptainer Def file usage:
# Mount the DB's into the container
    export APPTAINER_BIND="<local_path>:/opt/RoseTTAFold2NA/bfd,<local_path>:/opt/RoseTTAFold2NA/RNA,<local_path>:/opt/RoseTTAFold2NA/UniRef30_2020_06,<local_path>:/opt/RoseTTAFold2NA/pdb100_2021Mar03"

    # run rosetta2nafold
    apptainer run --nv <container_name> <output_dir> <fa_filename> <type_RNA_DNA>

-Removed from run_RF2na.sh on both PATHS for WDIR and SCRIPT the "-s" param
- adden in RF2na-linux.yml the pytorch version 2.0 to avoid the NVTX error
- fixed a typo in make_rna_msa.sh