### PR TITLE
Minor update to network/util.py

### DIFF
--- a/network/util.py
+++ b/network/util.py
@@ -227,7 +227,7 @@ def make_frame(X, Y):
     Xn = X / torch.linalg.norm(X)
     Y = Y - torch.dot(Y, Xn) * Xn
     Yn = Y / torch.linalg.norm(Y)
-    Z = torch.cross(Xn,Yn)
+    Z = torch.cross(Xn, Yn, dim=-1)
     Zn =  Z / torch.linalg.norm(Z)
     return torch.stack((Xn,Yn,Zn), dim=-1)
 


### PR DESCRIPTION
UserWarning: Using torch.cross without specifying the dim arg is deprecated.

Fix for minor issue #113 